### PR TITLE
[PATCH] check if direct type is set before trying the implied type

### DIFF
--- a/helper/syntax.php
+++ b/helper/syntax.php
@@ -544,9 +544,12 @@ class helper_plugin_strata_syntax extends DokuWiki_Plugin {
                     // try direct type first, implied type second
                     $vtype = $p->type($vtype);
                     $type = $p->type($type);
-                    if (isset ($type))
+                    if (isset ($vtype))
                     {
                       $this->updateTypemap($typemap, $object['text'], $vtype->type, $vtype->hint);
+                    }
+                    else
+                    {
                       $this->updateTypemap($typemap, $object['text'], $type->type, $type->hint);
                     }
                 } else {


### PR DESCRIPTION
Hello! This is a small patch for ``helpers/syntax.php`` that will first check if ``$vtype`` is set before resorting to using ``$type`` directly. 

It fixes the following error that prevents the strata plugin from displaying:

```
Got error 'PHP message: PHP Warning:  
Attempt to read property "type" on null in /var/www/dokuwiki/lib/plugins/strata/helper/syntax.php on line 549;
```

The patch follows the comment from a few lines before line 549, namely "try direct type first, implied type second" and first checks the direct type with a fallback on the implicit type.

Please apply if useful. Thanks!